### PR TITLE
Add search terms to find this application

### DIFF
--- a/share/applications/shutter.desktop
+++ b/share/applications/shutter.desktop
@@ -72,6 +72,7 @@ Type=Application
 Categories=Utility;
 MimeType=image/bmp;image/jpeg;image/gif;image/png;image/tiff;image/x-bmp;image/x-ico;image/x-png;image/x-pcx;image/x-tga;image/xpm;image/svg+xml;
 Actions=Redo;Select;Screen;Window;Active;
+Keywords=capture;print;screenshot;snapshot;
 
 [Desktop Action Redo]
 Name=Redo last screenshot


### PR DESCRIPTION
Add keywords to be able to search for 'screenshot' in the Gnome activities overview, regardless of the localization.

Signed-off-by: Volker Theile <votdev@gmx.de>