### PR TITLE
Fix appstream validation errors

### DIFF
--- a/share/appdata/shutter.appdata.xml
+++ b/share/appdata/shutter.appdata.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>org.shutterproject.shutter</id>
+  <name>Shutter</name>
+  <summary>The feature-rich screenshot tool</summary>
   <launchable type="desktop-id">shutter.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
-  <license>GPL-3.0+</license>
+  <project_license>GPL-3.0+</project_license>
   <description>
     <p>
       Shutter is a feature-rich screenshot program. You can take a screenshot of a
@@ -22,9 +24,17 @@
   <url type="bugtracker">https://github.com/shutter-project/shutter/issues</url>
   <url type="contact">https://shutter-project.org/contact/</url>
   <screenshots>
-    <screenshot type="default">https://shutter-project.org/wp-content/uploads/key_feature_030.png</screenshot>
-    <screenshot>https://shutter-project.org/wp-content/uploads/key_feature_042.png</screenshot>
-    <screenshot>https://shutter-project.org/wp-content/uploads/key_feature_036.png</screenshot>
-    <screenshot>https://shutter-project.org/wp-content/uploads/key_feature_073.png</screenshot>
+    <screenshot type="default">
+      <image>https://shutter-project.org/wp-content/uploads/key_feature_030.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://shutter-project.org/wp-content/uploads/key_feature_042.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://shutter-project.org/wp-content/uploads/key_feature_036.png</image>
+    </screenshot>
+    <screenshot>
+      <image>https://shutter-project.org/wp-content/uploads/key_feature_073.png</image>
+    </screenshot>
   </screenshots>
 </component>


### PR DESCRIPTION
Before:
```
root@590df40fac1a:~# appstreamcli validate shutter.appdata.xml 
I: org.shutterproject.shutter:8: unknown-tag license
E: org.shutterproject.shutter:27: screenshot-no-media
E: org.shutterproject.shutter:30: screenshot-no-media
I: org.shutterproject.shutter:~: content-rating-missing
E: org.shutterproject.shutter:28: screenshot-no-media
E: org.shutterproject.shutter:29: screenshot-no-media

? Validation failed: errors: 4, infos: 2, pedantic: 5
```
After:
```
root@590df40fac1a:~# appstreamcli validate shutter.appdata.xml 
I: org.shutterproject.shutter:~: content-rating-missing

? Validation was successful: infos: 1, pedantic: 5
```