### PR TITLE
Use XDG config folder instead of .shutter stray folder

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -260,6 +260,7 @@ my $so   = Shutter::App::Options->new($sc, $shf);
 #set home
 #--------------------------------------
 $ENV{'HOME'} = Shutter::App::Directories::get_home_dir();
+$ENV{'CONFIG'} = Shutter::App::Directories::get_config_dir();
 
 #--------------------------------------
 
@@ -892,7 +893,7 @@ sub STARTUP {
 	my $combobox_settings_profiles = Gtk3::ComboBoxText->new;
 	my @current_profiles;
 	my $current_index = 0;
-	foreach my $pfile (sort bsd_glob("$ENV{'HOME'}/.shutter/profiles/*.xml")) {
+	foreach my $pfile (sort bsd_glob("$ENV{'CONFIG'}/shutter/profiles/*.xml")) {
 		utf8::decode $pfile;
 		next
 			if $pfile =~ /\_accounts.xml/;    #accounts file - we are looking for "real" profiles
@@ -2758,7 +2759,7 @@ sub STARTUP {
 
 	#load saved settings
 	#--------------------------------------
-	my $folder_to_save = $settings_xml->{'general'}->{'folder'} || $ENV{'HOME'};
+	my $folder_to_save = $settings_xml->{'general'}->{'folder'} || $ENV{'CONFIG'};
 	my ($cmdname, $extra) = $sc->get_start_with;
 	if ($cmdname && $folder_to_save) {
 		evt_take_screenshot('global_keybinding', $cmdname, $folder_to_save, $extra);
@@ -3879,11 +3880,11 @@ sub STARTUP {
 		if ($combobox_settings_profiles->get_active_text) {
 			my $active_text  = $combobox_settings_profiles->get_active_text;
 			my $active_index = $combobox_settings_profiles->get_active;
-			unlink("$ENV{'HOME'}/.shutter/profiles/" . $active_text . ".xml");
-			unlink("$ENV{'HOME'}/.shutter/profiles/" . $active_text . "_accounts.xml");
+			unlink("$ENV{'CONFIG'}/shutter/profiles/" . $active_text . ".xml");
+			unlink("$ENV{'CONFIG'}/shutter/profiles/" . $active_text . "_accounts.xml");
 
-			unless ($shf->file_exists("$ENV{'HOME'}/.shutter/profiles/" . $active_text . ".xml")
-				|| $shf->file_exists("$ENV{'HOME'}/.shutter/profiles/" . $active_text . "_accounts.xml"))
+			unless ($shf->file_exists("$ENV{'CONFIG'}/shutter/profiles/" . $active_text . ".xml")
+				|| $shf->file_exists("$ENV{'CONFIG'}/shutter/profiles/" . $active_text . "_accounts.xml"))
 			{
 				$combobox_settings_profiles->remove_text($active_index);
 				$combobox_settings_profiles->set_active($combobox_settings_profiles->get_active + 1);
@@ -7900,7 +7901,7 @@ sub STARTUP {
 		$current_plugin->set_line_wrap(TRUE);
 		$plugin_dialog->get_child->add($current_plugin);
 
-		my @plugin_paths = ("$shutter_root/share/shutter/resources/system/plugins/*/*", "$ENV{'HOME'}/.shutter/plugins/*/*");
+		my @plugin_paths = ("$shutter_root/share/shutter/resources/system/plugins/*/*", "$ENV{'CONFIG'}/shutter/plugins/*/*");
 
 		#fallback icon
 		# maybe the plugin
@@ -10773,7 +10774,7 @@ sub STARTUP {
 		if ($profile_response eq 'accept') {
 			my $entered_name = $new_profile_name->get_text;
 
-			if ($shf->file_exists("$ENV{'HOME'}/.shutter/profiles/$entered_name.xml")) {
+			if ($shf->file_exists("$ENV{'CONFIG'}/shutter/profiles/$entered_name.xml")) {
 
 				#ask the user to replace the profile
 				#replace button

--- a/share/shutter/resources/modules/Shutter/App/Directories.pm
+++ b/share/shutter/resources/modules/Shutter/App/Directories.pm
@@ -30,11 +30,11 @@ use warnings;
 use Glib qw/ TRUE /;
 
 use constant {
-    SHUTTER_DIR        => "shutter",
-    UNSAVED_DIR        => "unsaved",
-    TEMP_DIR           => "temp",
-    AUTOSTART_DIR      => "autostart",
-    PROFILES_DIR       => "profiles"
+    SHUTTER_DIR   => "shutter",
+    UNSAVED_DIR   => "unsaved",
+    TEMP_DIR      => "temp",
+    AUTOSTART_DIR => "autostart",
+    PROFILES_DIR  => "profiles"
 };
 
 sub create_if_not_exists {

--- a/share/shutter/resources/modules/Shutter/App/Directories.pm
+++ b/share/shutter/resources/modules/Shutter/App/Directories.pm
@@ -34,7 +34,6 @@ use constant {
     UNSAVED_DIR        => "unsaved",
     TEMP_DIR           => "temp",
     AUTOSTART_DIR      => "autostart",
-    HIDDEN_SHUTTER_DIR => ".shutter",
     PROFILES_DIR       => "profiles"
 };
 

--- a/share/shutter/resources/modules/Shutter/App/Directories.pm
+++ b/share/shutter/resources/modules/Shutter/App/Directories.pm
@@ -66,7 +66,7 @@ sub get_home_dir   {Glib::get_home_dir}
 sub get_config_dir {Glib::get_user_config_dir}
 
 sub create_hidden_home_dir_if_not_exist {
-    my $hidden_dir          = $ENV{HOME} . "/" . HIDDEN_SHUTTER_DIR;
+    my $hidden_dir          = Glib::get_user_config_dir . "/" . SHUTTER_DIR;
     my $hidden_profiles_dir = "$hidden_dir" . "/" . PROFILES_DIR;
 
     mkdir $hidden_dir          unless -d $hidden_dir;

--- a/t/Shutter/App/02_directories.t
+++ b/t/Shutter/App/02_directories.t
@@ -13,6 +13,7 @@ require_ok("Shutter::App::Directories");
     # do not pollute /home with these tests
     my $local_home = tempdir( CLEANUP => 1 );
     local $ENV{HOME} = $local_home;
+    local $ENV{CONFIG} = $local_home . "/.config";
 
     subtest "create_if_not_exists" => sub {
         my $dir = tempdir( CLEANUP => 1 ) . "/foo";
@@ -72,7 +73,7 @@ require_ok("Shutter::App::Directories");
     };
 
     subtest "create_hidden_home_dir_if_not_exist" => sub {
-        my $hidden_dir   = $ENV{HOME} . "/" . Shutter::App::Directories->HIDDEN_SHUTTER_DIR;
+        my $hidden_dir   = $ENV{CONFIG} . "/" . Shutter::App::Directories->SHUTTER_DIR;
         my $profiles_dir = $hidden_dir . "/" . Shutter::App::Directories->PROFILES_DIR;
 
         ok( !-d $hidden_dir,   "hidden dir doesn't exist" );


### PR DESCRIPTION
Changed the sometimes hardcoded settings path to instead use
`.config/shutter` instead of `.shutter`. Respects XDG standards and the home folder.

**Needs testing since I know nothing about Perl and could not execute project.**