### PR TITLE
Make variables in fct_validate_filename local to fix #593

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -5601,8 +5601,8 @@ sub STARTUP {
 		my @invalid_codes = (47, 92);
 		$myfilename->signal_connect(
 			'key-press-event' => sub {
-				my $myfilename	= shift;
-				my $event	= shift;
+				shift(@_);
+				my $event = shift;
 
 				my $input = Gtk3::Gdk::keyval_to_unicode($event->keyval);
 

--- a/bin/shutter
+++ b/bin/shutter
@@ -5601,7 +5601,7 @@ sub STARTUP {
 		my @invalid_codes = (47, 92);
 		$myfilename->signal_connect(
 			'key-press-event' => sub {
-				shift(@_);
+				shift;
 				my $event = shift;
 
 				my $input = Gtk3::Gdk::keyval_to_unicode($event->keyval);

--- a/bin/shutter
+++ b/bin/shutter
@@ -5595,12 +5595,12 @@ sub STARTUP {
 	}
 
 	sub fct_validate_filename{
-		$filename	= shift;
-		$filename_hint	= shift;
+		my $myfilename	= shift;
+		my $myfilename_hint	= shift;
 		my @invalid_codes = (47, 92);
-		$filename->signal_connect(
+		$myfilename->signal_connect(
 			'key-press-event' => sub {
-				my $filename	= shift;
+				my $myfilename	= shift;
 				my $event	= shift;
 
 				my $input = Gtk3::Gdk::keyval_to_unicode($event->keyval);
@@ -5610,12 +5610,12 @@ sub STARTUP {
 				if (grep($input == $_, @invalid_codes)) {
 					my $char = chr($input);
 					$char = 'amp();' if $char eq '&';
-					$filename_hint->set_markup("<span size='small'>" . sprintf($d->get("Reserved character %s is not allowed to be in a filename."), "'" . $char . "'") . "</span>");
+					$myfilename_hint->set_markup("<span size='small'>" . sprintf($d->get("Reserved character %s is not allowed to be in a filename."), "'" . $char . "'") . "</span>");
 					return TRUE;
 				} else {
 
 					#clear possible message when valid char is entered
-					$filename_hint->set_markup("<span size='small'></span>");
+					$myfilename_hint->set_markup("<span size='small'></span>");
 					return FALSE;
 				}
 			});


### PR DESCRIPTION
Looks like calling fct_validate_filename() to check the profile name interfered with setting the filename variable from the settings dialog such that the latter has been set to an empty string for some reason. With all variables made local there shouldn't be any interference left.