### PR TITLE
Fix #604: setting saving location on profile loading was broken

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -4731,7 +4731,7 @@ sub STARTUP {
 					$filename->set_text($settings_xml->{'general'}->{'filename'});
 
 					utf8::decode $settings_xml->{'general'}->{'folder'};
-					$saveDir_button->set_current_folder($settings_xml->{'general'}->{'folder'});
+					$saveDir_button->set_filename($settings_xml->{'general'}->{'folder'});
 
 					$save_auto_active->set_active($settings_xml->{'general'}->{'save_auto'});
 					$save_ask_active->set_active($settings_xml->{'general'}->{'save_ask'});


### PR DESCRIPTION
`set_current_folder` changes which folder is shown when opening the file chooser, while `set_filename` changes the selected folder and thus the saving location setting.