### PR TITLE
Fix #597: The edit button is disabled

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -4953,6 +4953,11 @@ sub STARTUP {
 		#get applications
 		my $apps = Glib::IO::AppInfo::get_recommended_for_type('image/png');
 
+		# $apps is undefined if Glib::IO::AppInfo::get_recommended_for_type fails
+		unless (defined $apps) {
+			return $model;
+		}
+
 		#no apps determined!
 		unless (scalar @$apps) {
 			return $model;
@@ -8655,6 +8660,8 @@ sub STARTUP {
 
 		# $apps is undefined if Glib::IO::AppInfo::get_recommended_for_type fails
 		unless (defined $apps) {
+			$sm->{_menuitem_reopen}->set_sensitive(FALSE);
+			$sm->{_menuitem_large_reopen}->set_sensitive(FALSE);
 			return $menu_programs;
 		}
 

--- a/bin/shutter
+++ b/bin/shutter
@@ -8653,6 +8653,11 @@ sub STARTUP {
 		# https://developer.gnome.org/gio/stable/GAppInfo.html
 		my $apps = Glib::IO::AppInfo::get_recommended_for_type($mime_type);
 
+		# $apps is undefined if Glib::IO::AppInfo::get_recommended_for_type fails
+		unless (defined $apps) {
+			return $menu_programs;
+		}
+
 		#no apps determined!
 		unless (scalar @$apps) {
 			$sm->{_menuitem_reopen}->set_sensitive(FALSE);


### PR DESCRIPTION
For some reason due to `Glib::IO::AppInfo::get_recommended_for_type` failing to determine recommended apps for the "Open with" menu switching the edit button to sensitive fails. Checking `$apps` for being undefinied leaves the user without apps in the "Open with" menu but keeps the edit button enabled.