### PR TITLE
Reactivate Selection mode on Wayland

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -233,6 +233,7 @@ if ($goocanvas) {
 #screenshot classes
 require Shutter::Screenshot::SelectorAdvanced;
 require Shutter::Screenshot::SelectorAuto;
+require Shutter::Screenshot::SelectorWayland;
 require Shutter::Screenshot::Wayland;
 require Shutter::Screenshot::Workspace;
 require Shutter::Screenshot::Web;
@@ -535,7 +536,7 @@ sub STARTUP {
 	$sm->{_menuitem_iclipboard}->signal_connect('activate', \&fct_clipboard_import);
 
 	unless ($x11_supported) {
-		for my $name ('selection', 'awindow', 'window', 'menu', 'tooltip') {
+		for my $name ('awindow', 'window', 'menu', 'tooltip') {
 			$sm->{"_menuitem_$name"}->set_sensitive(FALSE);
 		}
 	}
@@ -873,12 +874,12 @@ sub STARTUP {
 
 	unless ($x11_supported) {
 		my $tooltip = $d->get("Can't take screenshots without X11 server");
-		for my $name ('_select', '_window', '_menu', '_tooltip') {
+		for my $name ('_window', '_menu', '_tooltip') {
 			$st->{$name}->set_sensitive(FALSE);
 			$st->{$name}->set_tooltip_text($tooltip);
 		}
-		for my $name ('_full', '_window') {
-			$st->{$name}->set_arrow_tooltip_text($tooltip);
+		for my $name ('_full', '_select', '_window') {
+#DEBUG			$st->{$name}->set_arrow_tooltip_text($tooltip);
 		}
 	}
 
@@ -2950,13 +2951,14 @@ sub STARTUP {
 			#unblock signal handler
 			fct_control_signals('unblock');
 			return TRUE;
-		} elsif (!$x11_supported && $data ne "full" && $data ne "tray_full") {
-			my $sd = Shutter::App::SimpleDialogs->new;
-			$sd->dlg_error_message($d->get("Can't take screenshots without X11 server"), $d->get("Failed"));
-			fct_control_signals('unblock');
-			fct_control_main_window('show');
-			return TRUE;
 		}
+# 		elsif (!$x11_supported && $data ne "full" && $data ne "tray_full") {
+# 			my $sd = Shutter::App::SimpleDialogs->new;
+# 			$sd->dlg_error_message($d->get("Can't take screenshots without X11 server"), $d->get("Failed"));
+# 			fct_control_signals('unblock');
+# 			fct_control_main_window('show');
+# 			return TRUE;
+# 		}
 
 		if ($data eq "menu"
 			|| $data eq "tray_menu"
@@ -4218,38 +4220,36 @@ sub STARTUP {
 		}
 
 		#enable/disable controls
-		if ($st->{_select} && $sm->{_menuitem_selection}) {
-			# if $x11_supported is false, we are on Wayland, and all these buttons are already disabled and should stay disabled
 
-			#menu
-			if ($x11_supported) {
-				$sm->{_menuitem_selection}->set_sensitive($sensitive);
-				$sm->{_menuitem_window}->set_sensitive($sensitive);
-				#$sm->{_menuitem_section}->set_sensitive($sensitive);
-				$sm->{_menuitem_menu}->set_sensitive($sensitive);
-				$sm->{_menuitem_tooltip}->set_sensitive($sensitive);
-			}
-			$sm->{_menuitem_web}->set_sensitive($sensitive)
-				if ($gnome_web_photo);
-			$sm->{_menuitem_iclipboard}->set_sensitive($sensitive);
-
-			#toolbar
-			if ($x11_supported) {
-				$st->{_select}->set_sensitive($sensitive);
-				$st->{_window}->set_sensitive($sensitive);
-				#$st->{_section}->set_sensitive($sensitive);
-				$st->{_menu}->set_sensitive($sensitive);
-				$st->{_tooltip}->set_sensitive($sensitive);
-			}
-			$st->{_web}->set_sensitive($sensitive) if ($gnome_web_photo);
-
-			#special case: redoshot (toolbar and menu)
-			if (fct_get_last_capture()) {
-				$st->{_redoshot}->set_sensitive($sensitive);
-				$sm->{_menuitem_redoshot}->set_sensitive($sensitive);
-			}
-
+		#menu
+		$sm->{_menuitem_selection}->set_sensitive($sensitive);
+		if ($x11_supported) {
+			$sm->{_menuitem_window}->set_sensitive($sensitive);
+			#$sm->{_menuitem_section}->set_sensitive($sensitive);
+			$sm->{_menuitem_menu}->set_sensitive($sensitive);
+			$sm->{_menuitem_tooltip}->set_sensitive($sensitive);
 		}
+		$sm->{_menuitem_web}->set_sensitive($sensitive)
+			if ($gnome_web_photo);
+		$sm->{_menuitem_iclipboard}->set_sensitive($sensitive);
+
+		#toolbar
+#DEBUG		$st->{_select}->set_sensitive($sensitive);
+		if ($x11_supported) {
+			$st->{_window}->set_sensitive($sensitive);
+			$st->{_section}->set_sensitive($sensitive);
+			$st->{_menu}->set_sensitive($sensitive);
+			$st->{_tooltip}->set_sensitive($sensitive);
+		}
+		$st->{_web}->set_sensitive($sensitive) if ($gnome_web_photo);
+
+		#special case: redoshot (toolbar and menu)
+		if (fct_get_last_capture()) {
+			$st->{_redoshot}->set_sensitive($sensitive);
+			$sm->{_menuitem_redoshot}->set_sensitive($sensitive);
+		}
+
+
 
 		return TRUE;
 	}
@@ -6047,14 +6047,17 @@ sub STARTUP {
 				$screenshot = $screenshooter->select_auto($coords[0], $coords[1], $coords[2], $coords[3]);
 
 			} else {
+				if ($x11_supported) {
+					$screenshooter = Shutter::Screenshot::SelectorAdvanced->new(
+						$sc,                      $include_cursor,        $delay_value,                $notify_timeout_active->get_active,
+						$zoom_active->get_active, $hide_time->get_value,  $as_help_active->get_active, $asel_size3->get_value,
+						$asel_size4->get_value,   $asel_size1->get_value, $asel_size2->get_value,
+					);
 
-				$screenshooter = Shutter::Screenshot::SelectorAdvanced->new(
-					$sc,                      $include_cursor,        $delay_value,                $notify_timeout_active->get_active,
-					$zoom_active->get_active, $hide_time->get_value,  $as_help_active->get_active, $asel_size3->get_value,
-					$asel_size4->get_value,   $asel_size1->get_value, $asel_size2->get_value,
-				);
-
-				$screenshot = $screenshooter->select_advanced();
+					$screenshot = $screenshooter->select_advanced();
+				} else {
+					$screenshot = Shutter::Screenshot::SelectorWayland::xdg_portal($screenshooter);
+				}
 
 			}
 
@@ -7761,8 +7764,8 @@ sub STARTUP {
 
 		print "Parsing wildcards for $screenshot_name\n"
 			if $sc->get_debug;
-		
-		# $screenshot is undefined if the selection width or height is zero 
+
+		# $screenshot is undefined if the selection width or height is zero
 		unless ($screenshot) {
 			my $response = $sd->dlg_error_message($d->get("Error: selection width or height is zero, please retry!"), $d->get("Failed"));
 			fct_control_main_window('show');
@@ -8437,7 +8440,7 @@ sub STARTUP {
 
 		#selection
 		my $menuitem_select = Gtk3::ImageMenuItem->new_with_mnemonic($d->get('_Selection'));
-		$menuitem_select->set_sensitive($x11_supported);
+		$menuitem_select->set_sensitive(TRUE);
 		eval {
 			my $ccursor_pb = Gtk3::Gdk::Cursor::new('left_ptr')->get_image->scale_simple($shf->icon_size('menu'), 'bilinear');
 			$menuitem_select->set_image(Gtk3::Image->new_from_pixbuf($ccursor_pb));

--- a/share/shutter/resources/modules/Shutter/Screenshot/SelectorWayland.pm
+++ b/share/shutter/resources/modules/Shutter/Screenshot/SelectorWayland.pm
@@ -19,12 +19,11 @@ sub xdg_portal {
 	my $pixbuf;
 	my $output;
 
-	#eval {
+	eval {
 		my $portal_service = $bus->get_service('org.freedesktop.portal.Desktop');
 		my $portal = $portal_service->get_object('/org/freedesktop/portal/desktop', 'org.freedesktop.portal.Screenshot');
 
 		my $num;
-		my $output;
 		my $cb = sub {
 			($num, $output) = @_;
 			$reactor->shutdown;
@@ -60,7 +59,7 @@ sub xdg_portal {
 
 		$output = take_screenshot($s, $pixbuf);
 		$giofile->delete;
-	#};
+	};
 	if ($@) {
 		$screenshooter->{_error_text} = $@;
 		return 9;

--- a/share/shutter/resources/modules/Shutter/Screenshot/SelectorWayland.pm
+++ b/share/shutter/resources/modules/Shutter/Screenshot/SelectorWayland.pm
@@ -1,0 +1,96 @@
+use utf8;
+use strict;
+use warnings;
+use Net::DBus;
+use Net::DBus::Reactor;
+use Class::Struct;
+use Data::Dumper;
+
+package Shutter::Screenshot::SelectorWayland;
+
+sub xdg_portal {
+	my $screenshooter = shift;
+	my $reactor = Net::DBus::Reactor->main;
+	my $bus = Net::DBus->find;
+	my $me = $bus->get_unique_name;
+	$me =~ s/\./_/g;
+	$me =~ s/^://g;
+
+	my $pixbuf;
+	my $output;
+
+	#eval {
+		my $portal_service = $bus->get_service('org.freedesktop.portal.Desktop');
+		my $portal = $portal_service->get_object('/org/freedesktop/portal/desktop', 'org.freedesktop.portal.Screenshot');
+
+		my $num;
+		my $output;
+		my $cb = sub {
+			($num, $output) = @_;
+			$reactor->shutdown;
+		};
+
+		my $token = 'shutter' . rand;
+		$token =~ s/\.//g;
+		my $request = $portal_service->get_object("/org/freedesktop/portal/desktop/request/$me/$token", 'org.freedesktop.portal.Request');
+		my $conn = $request->connect_to_signal(Response => $cb);
+		my $request_path = $portal->Screenshot('', {handle_token=>$token});
+		if ($request->get_object_path ne $request_path) {
+			$request->disconnect_from_signal(Response => $conn);
+			$request = $portal_service->get_object($request_path, 'org.freedesktop.portal.Request');
+			$conn = $request->connect_to_signal(Response => $cb);
+		}
+		$reactor->run;
+		$request->disconnect_from_signal(Response => $conn);
+		if ($num != 0) {
+			$screenshooter->{_error_text} = "Response $num from XDG portal";
+			return 9;
+		}
+		my $giofile = Glib::IO::File::new_for_uri($output->{uri});
+		print "xdg portal: got file ".$giofile->get_path."\n";
+		$pixbuf = Gtk3::Gdk::Pixbuf->new_from_file($giofile->get_path);
+		my $slurpoutput = `slurp`;
+		my ($x, $y, $width, $height) = split /[,x ]/, $slurpoutput;
+		my $s = {
+			'y' 		=> $y,
+			'width' 	=> $width,
+			'height'	=> $height,
+			'x'			=> $x
+		};
+
+		$output = take_screenshot($s, $pixbuf);
+		$giofile->delete;
+	#};
+	if ($@) {
+		$screenshooter->{_error_text} = $@;
+		return 9;
+	};
+
+	return $output;
+}
+
+sub take_screenshot {
+	#my $self         = shift;
+	my $s            = shift;
+	my $clean_pixbuf = shift;
+
+	#my $d = $self->{_sc}->get_gettext;
+
+	my $output;
+
+	#no delay? then we take a subsection of the pixbuf in memory
+	if ($s && $clean_pixbuf ) {
+
+		$output = $clean_pixbuf->new_subpixbuf($s->{x}, $s->{y}, $s->{width}, $s->{height});
+
+		print "DEBUG OUTPUT=" . $output . "\n";
+
+		#if there is a delay != 0 set, we have to wait and get a new pixbuf from the root window
+	} else {
+		$output = 0;
+	}
+
+	return $output;
+}
+
+1;


### PR DESCRIPTION
So far this crashes on X11 for some reason... It gives

```
[...]
INFO: gathering system information...

Shutter 0.99.4 Rev.1608
Linux photon-virtualbox 6.1.44-1-MANJARO #1 SMP PREEMPT_DYNAMIC Wed Aug  9 09:02:26 UTC 2023 x86_64 GNU/Linux

Manjaro Linux \r  (\n) (\l)



Glib 1.3293 
Gtk3 0.038 

Glib built for 2.76.4, running with 2.76.4

Can't call method "set_sensitive" on an undefined value at ./shutter line 4239.
        Shutter::App::fct_control_signals("block") called at ./shutter line 804
        Shutter::App::STARTUP(Shutter::App=HASH(0x5575fedce8d8)) called at /usr/lib/perl5/5.38/vendor_perl/Glib/Object/Introspection.pm line 67
        Glib::Object::Introspection::__ANON__(Shutter::App=HASH(0x5575fedce8d8)) called at ./shutter line 10981
zsh: segmentation fault (core dumped)  ./shutter

```