### PR TITLE
Added webp as additional image format

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -2864,7 +2864,10 @@ sub STARTUP {
 			} elsif ($combobox_type->get_active_text =~ /jpg/) {
 				$settings->set_jpg_quality($scale->get_value);
 			} elsif ($combobox_type->get_active_text =~ /png/) {
-				$settings->set_png_quality($scale->get_value);
+				$settings->set_jpg_quality($scale->get_value);
+			} elsif ($combobox_type->get_active_text =~ /webp/) {
+				print $scale->get_value . "\n\n\n";
+				$settings->set_webp_quality($scale->get_value);
 			} else {
 				$settings->clear_quality_settings();
 			}
@@ -2904,6 +2907,12 @@ sub STARTUP {
 				$scale->set_range(0, 9);
 				$scale->set_value(9);
 				$scale_label->set_text($d->get("Compression") . ":");
+			} elsif ($combobox_type->get_active_text =~ /webp/) {
+				$scale->set_sensitive(TRUE);
+				$scale_label->set_sensitive(TRUE);
+				$scale->set_range(0, 100);
+				$scale->set_value(98);
+				$scale_label->set_text($d->get("Quality") . ":");
 			} else {
 				$scale->set_sensitive(FALSE);
 				$scale_label->set_sensitive(FALSE);
@@ -9727,6 +9736,8 @@ sub STARTUP {
 							} elsif ($mime eq "image/png" && $ext eq ".png") {
 								$combobox_save_as_type->set_active($counter);
 							} elsif ($mime eq "image/bmp" && $ext eq ".bmp") {
+								$combobox_save_as_type->set_active($counter);
+							} elsif ($mime eq "image/webp" && $ext eq ".webp") {
 								$combobox_save_as_type->set_active($counter);
 							}
 						}

--- a/bin/shutter
+++ b/bin/shutter
@@ -2866,7 +2866,6 @@ sub STARTUP {
 			} elsif ($combobox_type->get_active_text =~ /png/) {
 				$settings->set_jpg_quality($scale->get_value);
 			} elsif ($combobox_type->get_active_text =~ /webp/) {
-				print $scale->get_value . "\n\n\n";
 				$settings->set_webp_quality($scale->get_value);
 			} else {
 				$settings->clear_quality_settings();

--- a/bin/shutter
+++ b/bin/shutter
@@ -1115,13 +1115,14 @@ sub STARTUP {
 
 	#add compatile, writeable file types
 	my $combobox_type = Gtk3::ComboBoxText->new;
-	my ($int_png, $int_jpeg, $int_bmp) = (-1, -1, -1);
+	my ($int_png, $int_jpeg, $int_bmp, $int_webp) = (-1, -1, -1);
 	my $format_counter = 0;
 
 	foreach my $format (Gtk3::Gdk::Pixbuf::get_formats()) {
 		if (   $format->get_name eq "jpeg"
 			|| $format->get_name eq "png"
-			|| $format->get_name eq "bmp")
+			|| $format->get_name eq "bmp"
+			|| $format->get_name eq "webp")
 		{
 
 			#we want jpg not jpeg
@@ -1139,6 +1140,8 @@ sub STARTUP {
 				$int_png = $format_counter;
 			} elsif ($format->get_name eq "bmp") {
 				$int_bmp = $format_counter;
+			} elsif ($format->get_name eq "webp") {
+				$int_webp = $format_counter;
 			}
 
 			$format_counter++;
@@ -1180,7 +1183,7 @@ sub STARTUP {
 	} else {
 
 		#we will try to set a default value in this order
-		foreach my $cformat (@{[$int_png, $int_jpeg, $int_bmp]}) {
+		foreach my $cformat (@{[$int_png, $int_jpeg, $int_bmp, $int_webp]}) {
 			if ($cformat > -1) {
 				$combobox_type->set_active($cformat);
 				last;

--- a/bin/shutter
+++ b/bin/shutter
@@ -1115,7 +1115,7 @@ sub STARTUP {
 
 	#add compatile, writeable file types
 	my $combobox_type = Gtk3::ComboBoxText->new;
-	my ($int_png, $int_jpeg, $int_bmp, $int_webp) = (-1, -1, -1);
+	my ($int_png, $int_jpeg, $int_bmp, $int_webp) = (-1, -1, -1, -1);
 	my $format_counter = 0;
 
 	foreach my $format (Gtk3::Gdk::Pixbuf::get_formats()) {

--- a/share/shutter/resources/modules/Shutter/App/GlobalSettings.pm
+++ b/share/shutter/resources/modules/Shutter/App/GlobalSettings.pm
@@ -39,6 +39,7 @@ sub new {
 
 	$self->{_png_quality} = undef;
 	$self->{_jpg_quality} = undef;
+	$self->{_webp_quality} = undef;
 
 	bless $self, $class;
 	return $self;
@@ -63,6 +64,15 @@ sub get_jpg_quality {
 	}
 }
 
+sub get_webp_quality {
+	my $self = shift;
+	if (defined $self->{_webp_quality}) {
+		return $self->{_webp_quality};
+	} else {
+		return 98;
+	}
+}
+
 sub set_png_quality {
 	my $self = shift;
 	if (@_) {
@@ -79,10 +89,19 @@ sub set_jpg_quality {
 	return $self->{_jpg_quality};
 }
 
+sub set_webp_quality {
+	my $self = shift;
+	if (@_) {
+		$self->{_webp_quality} = shift;
+	}
+	return $self->{_webp_quality};
+}
+
 sub clear_quality_settings {
 	my $self = shift;
 	$self->{_jpg_quality} = undef;
 	$self->{_png_quality} = undef;
+	$self->{_webp_quality} = undef;
 }
 
 1;

--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -129,7 +129,7 @@ sub save_pixbuf_to_file {
 
 		print "Saving file $filename, $filetype, $quality\n" if $self->{_common}->get_debug;
 
-		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", compression => $quality); };
+		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", quality => $quality); };
 	} elsif ($filetype eq 'bmp') {
 		eval { $pixbuf->save($filename, $filetype); };
 	} elsif ($filetype eq 'webp') {

--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -129,7 +129,7 @@ sub save_pixbuf_to_file {
 
 		print "Saving file $filename, $filetype, $quality\n" if $self->{_common}->get_debug;
 
-		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", quality => $quality); };
+		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", compression => $quality); };
 	} elsif ($filetype eq 'bmp') {
 		eval { $pixbuf->save($filename, $filetype); };
 	} elsif ($filetype eq 'webp') {
@@ -147,7 +147,7 @@ sub save_pixbuf_to_file {
 
 		print "Saving file $filename, $filetype, $quality\n" if $self->{_common}->get_debug;
 
-		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", compression => $quality); };
+		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", quality => $quality); };
 	} elsif ($filetype eq 'pdf') {
 
 		print "Saving file $filename, $filetype\n" if $self->{_common}->get_debug;

--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -132,6 +132,22 @@ sub save_pixbuf_to_file {
 		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", compression => $quality); };
 	} elsif ($filetype eq 'bmp') {
 		eval { $pixbuf->save($filename, $filetype); };
+	} elsif ($filetype eq 'webp') {
+
+		#get quality value from settings if not set
+		if (my $settings = $self->{_common}->get_globalsettings_object) {
+			if (defined $settings->get_webp_quality) {
+				$quality = $settings->get_webp_quality;
+			} else {
+				$quality = 98;
+			}
+		} else {
+			$quality = 98;
+		}
+
+		print "Saving file $filename, $filetype, $quality\n" if $self->{_common}->get_debug;
+
+		eval { $pixbuf->save($filename, $filetype, "tEXt::Software" => "Shutter", compression => $quality); };
 	} elsif ($filetype eq 'pdf') {
 
 		print "Saving file $filename, $filetype\n" if $self->{_common}->get_debug;


### PR DESCRIPTION
Added webp as additional image format. Requires `webp-pixbuf-loader` as addition dependency. If the dependency is missing, webp is not listed among the available image formats.