### PR TITLE
Fix #162: Removes panic in Autostart package

### DIFF
--- a/share/shutter/resources/modules/Shutter/App/Autostart.pm
+++ b/share/shutter/resources/modules/Shutter/App/Autostart.pm
@@ -56,7 +56,10 @@ sub create_autostart_file {
 
 	my $path = $dir . "/shutter.desktop";
 
-	open FILE, ">:utf8", $path or die $!;
+	open FILE, ">:utf8", $path or do {
+		warn "WARNING: can not create/update file $path: $!\n";
+		return FALSE;
+	};
 	foreach my $line (@data) {
 		if ($line =~ /Exec=shutter<options>/) {
 
@@ -74,7 +77,7 @@ sub create_autostart_file {
 		}
 		print FILE $line;
 	}
-	close FILE or die $!;
+	close FILE or warn "WARNING: close $path fail: $!\n";
 
 	return TRUE;
 }


### PR DESCRIPTION
Panic in Auotstart::create_autostart_file hang up the application. Log
example:

```
*** unhandled exception in callback:
***   Not a directory at /usr/share/perl5/Shutter/App/Autostart.pm line 59.
***   	Shutter::App::Autostart::create_autostart_file(Shutter::App::Autostart=HASH(0x555ef7853e08), "/home/user/.config/autostart", "", "", "") called at /usr/bin/shutter line 3189
***   	Shutter::App::__ANON__() called at /usr/lib/x86_64-linux-gnu/perl5/5.38/Glib/Object/Introspection.pm line 67
***   	eval {...} called at /usr/lib/x86_64-linux-gnu/perl5/5.38/Glib/Object/Introspection.pm line 67
***   	Glib::Object::Introspection::__ANON__(Shutter::App=HASH(0x555ef76dcf20)) called at /usr/bin/shutter line 10943
***  ignoring at /usr/lib/x86_64-linux-gnu/perl5/5.38/Glib/Object/Introspection.pm line 67.
```