### PR TITLE
FIx typo when setting png quality

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -2874,7 +2874,7 @@ sub STARTUP {
 			} elsif ($combobox_type->get_active_text =~ /jpg/) {
 				$settings->set_jpg_quality($scale->get_value);
 			} elsif ($combobox_type->get_active_text =~ /png/) {
-				$settings->set_jpg_quality($scale->get_value);
+				$settings->set_png_quality($scale->get_value);
 			} elsif ($combobox_type->get_active_text =~ /webp/) {
 				$settings->set_webp_quality($scale->get_value);
 			} else {


### PR DESCRIPTION
FIx typo when setting png quality which meant that zero / low compression settings were not used for png images