### PR TITLE
Replace depricated action

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-name: CI
+tname: CI
 
 on:
   push:
@@ -35,6 +35,4 @@ jobs:
       - name: Run tests
         env:
           TEST_APP_SHUTTER_PATH: ${{ env.GITHUB_WORKSPACE }}
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: prove -I share/shutter/resources/modules/ -I t/lib t -r
+        run: xvfb-run --auto-servernum prove -I share/shutter/resources/modules/ -I t/lib t -r

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,4 +1,4 @@
-tname: CI
+name: CI
 
 on:
   push:


### PR DESCRIPTION
The xvfb-run action is [depricated](https://github.com/marketplace/actions/gabrielbb-xvfb-action) and since github images ship xvfb natively, we can safely remove the use of the action.