### PR TITLE
Fixes crash that has been reported in #659 by disabling the window list

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -8443,6 +8443,8 @@ sub STARTUP {
 
 		#add all windows to menu to capture it directly
 
+		return $menu_windows unless $wnck_screen->get_windows_stacked;
+
 		print "\n\n\nDEBUG\n\n\n";
 		print $wnck_screen;
 		print "\n\n\nDEBUG\n\n\n";

--- a/bin/shutter
+++ b/bin/shutter
@@ -8441,15 +8441,14 @@ sub STARTUP {
 		$menu_windows->append($active_window_item);
 		$menu_windows->append(Gtk3::SeparatorMenuItem->new);
 
+		# Check if we can retrieve the list of stacked windows first, otherwise we will run into a crash, see issue 659
+		
+		unless ($wnck_screen->get_windows_stacked) {
+			print "ERROR: The window list could not be retrieved and has been disabled, see https://github.com/shutter-project/shutter/issues/659";
+			return $menu_windows;
+		}
+
 		#add all windows to menu to capture it directly
-
-		return $menu_windows unless $wnck_screen->get_windows_stacked;
-
-		print "\n\n\nDEBUG\n\n\n";
-		print $wnck_screen;
-		print "\n\n\nDEBUG\n\n\n";
-		print @{$wnck_screen->get_windows_stacked};
-		print "\n\n\nDEBUG\n\n\n";
 
 		foreach my $win (@{$wnck_screen->get_windows_stacked}) {
 			if ($active_workspace && $win->is_on_workspace($active_workspace)) {

--- a/bin/shutter
+++ b/bin/shutter
@@ -8442,6 +8442,13 @@ sub STARTUP {
 		$menu_windows->append(Gtk3::SeparatorMenuItem->new);
 
 		#add all windows to menu to capture it directly
+
+		print "\n\n\nDEBUG\n\n\n";
+		print $wnck_screen;
+		print "\n\n\nDEBUG\n\n\n";
+		print @{$wnck_screen->get_windows_stacked};
+		print "\n\n\nDEBUG\n\n\n";
+
 		foreach my $win (@{$wnck_screen->get_windows_stacked}) {
 			if ($active_workspace && $win->is_on_workspace($active_workspace)) {
 				my $win_name = $win->get_name;


### PR DESCRIPTION
Since we couldn't figure out why under some circumstances the window list cannot be retrieved, we should at least get rid of the crash.

If people are disturbed by the absence of the window list, they will find an error message in command line output which points them to the issue report dealing with this issue.

The problem appears if the window manager doesn't support EWMH (for example, DWM only supports it with some optional patches) or, for some reason, in KDE.