### PR TITLE
Set explicit message locale to C to be able to match error messages w…

### DIFF
--- a/t/Shutter/Draw/001_update_warning_text.t
+++ b/t/Shutter/Draw/001_update_warning_text.t
@@ -8,6 +8,10 @@ use Locale::gettext;
 use Test::More;
 use Test::MockModule;
 
+use POSIX qw(locale_h);
+use locale;
+setlocale(LC_MESSAGES, 'C'); # Allow non-English developers to match error messages
+
 require_ok('Shutter::Draw::DrawingTool');
 
 my $mock = Test::MockModule->new("Shutter::Draw::DrawingTool");


### PR DESCRIPTION
…hen not running in english environments