### PR TITLE
Re #218 Don't leak pixelated data

### DIFF
--- a/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
+++ b/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
@@ -2425,7 +2425,7 @@ sub get_pixelated_pixbuf_from_canvas {
 	my $sh     = $item->get('height');
 
 	#create surface and cairo context
-	my $surface = Cairo::ImageSurface->create('argb32', $bounds->x1 + $sw, $bounds->y1 + $sh);
+	my $surface = Cairo::ImageSurface->create('rgb24', $bounds->x1 + $sw, $bounds->y1 + $sh);
 	my $cr      = Cairo::Context->create($surface);
 
 	#hide rects and image


### PR DESCRIPTION
Before this change, pixelization would often "leak" unpixelized data "under" pixelized data. This change removes the ability from the pixelized rectangle to do alpha blending.

Here is a screen share from before the change:

https://github.com/user-attachments/assets/e1a20a3b-d127-4270-ae24-63097558920b

Here is one after the change:

https://github.com/user-attachments/assets/f401c15c-d40b-448e-9115-5ad7ce1dc941