### PR TITLE
Set default value for debug to 0 in order to prevent debug output

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -252,7 +252,8 @@ my $sc = Shutter::App::Common->new(
 	appname => SHUTTER_NAME,
 	version => SHUTTER_VERSION,
 	rev => SHUTTER_REV,
-	pid => $PID
+	pid => $PID,
+	debug => 0
 );
 my $shf  = Shutter::App::HelperFunctions->new($sc);
 my $so   = Shutter::App::Options->new($sc, $shf);


### PR DESCRIPTION
The default value has never been set and checks for it  returned true for some reason, so debug output has been printed to stdout. Now the default value is being set to 0 such that the debug output is only printed if the user specifies the `--debug` option as start parameter.