### PR TITLE
fix duplicated tray icons after slow reloading of some X window manager

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -774,6 +774,9 @@ sub STARTUP {
 		fct_try_init_tray();
 		Glib::Timeout->add(10000, sub {
 			if (!$tray_legacy || !$tray_legacy->is_embedded) {
+				if ($tray_legacy) {
+					$tray_legacy->set_visible(0);
+				}
 				fct_try_init_tray();
 			}
 			return TRUE;


### PR DESCRIPTION
A workaround to fix shutter-project/shutter#764 . The embedded status can keep false for a while during reloading of some X window manager (system tray included). The every-10-sec icon status checking may hit this time slice and create duplicated tray icons.