### PR TITLE
Fix GLib-CRITIAL on Glib::Source->remove for One-Time Timeout Source

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -7089,10 +7089,8 @@ sub STARTUP {
 		my $status_text = shift;
 
 		$status->pop($index);
-		if (defined $session_start_screen{'first_page'}->{'statusbar_timer'}) {
-			if ($session_start_screen{'first_page'}->{'statusbar_timer'}) {
-				Glib::Source->remove($session_start_screen{'first_page'}->{'statusbar_timer'});
-			}
+		if ($session_start_screen{'first_page'}->{'statusbar_timer'}) {
+			Glib::Source->remove($session_start_screen{'first_page'}->{'statusbar_timer'});
 		}
 		$status->push($index, $status_text);
 

--- a/bin/shutter
+++ b/bin/shutter
@@ -7101,6 +7101,8 @@ sub STARTUP {
 			3000,
 			sub {
 				$status->pop($index);
+				# avoid remove non-exist source
+				$session_start_screen{'first_page'}->{'statusbar_timer'} = 0;
 
 				#show file or session info again
 				fct_update_info_and_tray();

--- a/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
+++ b/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
@@ -154,8 +154,8 @@ sub new {
 			'enter-notify-event' => sub {
 
 				#remove old handler
-				if (defined $self->{_enter_notify_timeout}) {
-					Glib::Source->remove($self->{_enter_notify_timeout}) if $self->{_enter_notify_timeout};
+				if ($self->{_enter_notify_timeout}) {
+					Glib::Source->remove($self->{_enter_notify_timeout});
 				}
 
 				#current monitor
@@ -196,8 +196,8 @@ sub show {
 	my $self = shift;
 
 	#remove old handler
-	if (defined $self->{_notifications_timeout}) {
-		Glib::Source->remove($self->{_notifications_timeout}) if $self->{_notifications_timeout};
+	if ($self->{_notifications_timeout}) {
+		Glib::Source->remove($self->{_notifications_timeout});
 	}
 
 	#set body and summary

--- a/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
+++ b/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
@@ -155,7 +155,7 @@ sub new {
 
 				#remove old handler
 				if (defined $self->{_enter_notify_timeout}) {
-					Glib::Source->remove($self->{_enter_notify_timeout});
+					Glib::Source->remove($self->{_enter_notify_timeout}) if $self->{_enter_notify_timeout};
 				}
 
 				#current monitor
@@ -173,6 +173,8 @@ sub new {
 					100,
 					sub {
 						$self->show($self->{_summary}, $self->{_body});
+						$self->{_enter_notify_timeout} = 0;
+						return FALSE;
 					});
 
 				return FALSE;
@@ -195,7 +197,7 @@ sub show {
 
 	#remove old handler
 	if (defined $self->{_notifications_timeout}) {
-		Glib::Source->remove($self->{_notifications_timeout});
+		Glib::Source->remove($self->{_notifications_timeout}) if $self->{_notifications_timeout};
 	}
 
 	#set body and summary
@@ -210,6 +212,8 @@ sub show {
 		3000,
 		sub {
 			$self->close;
+			$self->{_notifications_timeout} = 0;
+			return FALSE;
 		});
 
 	return 0;

--- a/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
+++ b/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
@@ -1308,7 +1308,7 @@ sub quit {
 	$self->{_drawing_window}->destroy if $self->{_drawing_window};
 
 	#remove statusbar timer
-	Glib::Source->remove($self->{_drawing_statusbar}->{statusbar_timer}) if defined $self->{_drawing_statusbar}->{statusbar_timer};
+	#Glib::Source->remove($self->{_drawing_statusbar}->{statusbar_timer}) if defined $self->{_drawing_statusbar}->{statusbar_timer};
 
 	#delete hash entries to avoid any
 	#possible circularity


### PR DESCRIPTION
One-Time Timeout Source would be auto removed when callback ended. Then the Source ID is freed to a pool for reuse and can be assigned to other new source. Hitting a freed ID means the program on risk of wrongly hitting a reused ID, which is unexpected.

This commit fixes the usage of one-time Timeout sources by resetting ID records in callbacks and checking them before Source->remove calls. Also, some unused Source->remove code cleaned up in this commit.

Fix shutter-project/shutter#768