### PR TITLE
Fix missing GDK_SELECTION_CLIPBOARD

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -415,7 +415,7 @@ sub STARTUP {
 	#--------------------------------------
 
 	#Clipboard
-	$clipboard = Gtk3::Clipboard::get($Gtk3::Gdk::SELECTION_CLIPBOARD);
+	$clipboard = Gtk3::Clipboard::get(Gtk3::Gdk::Atom::intern("clipboard", FALSE));
 
 	#Gettext
 	$d = $sc->get_gettext;


### PR DESCRIPTION
Gtk3::Gdk::SELECTION_XXXX is neither a constant nor a package variant. So `undef` is passed in Gtk3::Clipboard::get() with warnings.

This commit has Gtk3::Gdk::Atom::intern involved to help fetching any valid selection types such as GDK_SELECTION_CLIPBOARD, GDK_SELECTION_PRIMARY and so on.

Fix shutter-project/shutter#772