### PR TITLE
Fix GLib::GObject::CRITICAL on out-of-range zoom factor (Gtk3::ImageV…

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -57,6 +57,23 @@ BEGIN {
 	);
 }
 
+package Gtk3::ImageViewCustom;
+
+use Gtk3::ImageView;
+use Glib::Object::Subclass Gtk3::ImageView::, properties => [
+	# override minium zoom
+	Glib::ParamSpec->float(
+		'zoom',		#name
+		'zoom',		#nick
+		'zoom level',	#blurb
+		0.0001,		#minium, tuned to fit 4K/8K modern display
+		100,		#maximum
+		1.0,		#default
+		[qw/readable writable/],
+	),
+];
+
+
 package Shutter::App;
 
 #Deal with encoding problem
@@ -71,7 +88,6 @@ use Pango;
 use Glib qw/TRUE FALSE/;
 use Gtk3 '-init';
 use Glib::Object::Subclass qw/Gtk3::Application/;
-use Gtk3::ImageView 10;
 
 #filename parsing
 use POSIX qw/ strftime /;
@@ -4428,7 +4444,7 @@ sub STARTUP {
 		unless ($is_all) {
 
 			#Gtk2::ImageView - empty at first
-			$session_screens{$key}->{'image'} = Gtk3::ImageView->new();
+			$session_screens{$key}->{'image'} = Gtk3::ImageViewCustom->new();
 			#$session_screens{$key}->{'image'}->set_show_frame(FALSE);
 			$session_screens{$key}->{'image'}->set_fitting(TRUE);
 			$session_screens{$key}->{'image'}->get_style_context->add_provider($css_provider_alpha, 0);

--- a/bin/shutter
+++ b/bin/shutter
@@ -59,7 +59,7 @@ BEGIN {
 
 package Gtk3::ImageViewCustom;
 
-use Gtk3::ImageView;
+use Gtk3::ImageView 10;
 use Glib::Object::Subclass Gtk3::ImageView::, properties => [
 	# override minium zoom
 	Glib::ParamSpec->float(

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 requires "Gtk3";
 requires "Pango";
 requires "Glib";
-requires "Gtk3::ImageView";
+requires "Gtk3::ImageView", ">= 10";
 requires "Number::Bytes::Human";
 requires "XML::Simple";
 requires "Net::DBus";


### PR DESCRIPTION
…iew)

The zoom factor have a minimum value 0.001 by default. To fit high-resolution display (4K/8K), a minimum value 0.0001 is perferred. Or boring CRITICAL messages are frequently printed.

This commit gets the minimum value tuned for ImageView used by screenshot tabs.

Fix shutter-project/shutter#774