### PR TITLE
use Pango loaded by Gtk3 to avoid GLib-GObject-CRITICAL and align Pan…

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -55,6 +55,11 @@ BEGIN {
 		version  => '3.0',
 		package  => 'Gtk3::GdkX11',
 	);
+	Glib::Object::Introspection->setup(
+		basename => 'PangoCairo',
+		version  => '1.0',
+		package  => 'Pango::Cairo',
+	);
 }
 
 package Shutter::App;
@@ -67,7 +72,6 @@ use File::stat;
 use Number::Bytes::Human;
 
 #Glib
-use Pango;
 use Glib qw/TRUE FALSE/;
 use Gtk3 '-init';
 use Glib::Object::Subclass qw/Gtk3::Application/;

--- a/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
+++ b/share/shutter/resources/modules/Shutter/App/ShutterNotification.pm
@@ -31,9 +31,8 @@ use warnings;
 #Glib
 use Glib qw/TRUE FALSE/;
 
-#Gtk3 and Pango
+#Gtk3
 use Gtk3;
-use Pango;
 
 #--------------------------------------
 
@@ -98,26 +97,18 @@ sub new {
 				my $style     = $self->{_sc}->get_mainwindow->get_style_context;
 				my $sel_bg    = Gtk3::Gdk::RGBA::parse('#131313');
 				my $font_fam  = $style->get_font('normal')->get_family;
-				my $font_size = $style->get_font('normal')->get_size / Pango->scale;
+				my $font_size = $style->get_font('normal')->get_size / Pango::SCALE;
 
 				#create cairo context
 				my $cr = $_[1];
 
 				#pango layout
 				my $layout = Pango::Cairo::create_layout($cr);
-				$layout->set_width(($w - 30) * Pango->scale);
+				$layout->set_width(($w - 30) * Pango::SCALE);
 
-				if (Pango->CHECK_VERSION(1, 20, 0)) {
-					$layout->set_height(($h - 20) * Pango->scale);
-				} else {
-					warn "WARNING: \$layout->set_height is not available - outdated Pango version\n";
-				}
+				$layout->set_height(($h - 20) * Pango::SCALE);
 
-				if (Pango->CHECK_VERSION(1, 6, 0)) {
-					$layout->set_ellipsize('middle');
-				} else {
-					warn "WARNING: \$layout->set_ellipsize is not available - outdated Pango version\n";
-				}
+				$layout->set_ellipsize('middle');
 
 				$layout->set_alignment('left');
 				$layout->set_wrap('word-char');

--- a/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
+++ b/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
@@ -632,7 +632,7 @@ sub setup_bottom_hbox {
 
 	$self->{_font_btn_wh} = $self->{_font_btn_w}->signal_connect(
 		'font-set' => sub {
-			my $font_descr = Pango::FontDescription->from_string($self->{_font_btn_w}->get_font_name);
+			my $font_descr = Pango::FontDescription::from_string($self->{_font_btn_w}->get_font_name);
 			$self->{_font} = $self->{_font_btn_w}->get_font_name;
 
 			if ($self->{_current_item}) {
@@ -3190,8 +3190,9 @@ sub set_and_save_drawing_properties {
 			if (exists($self->{_items}{$key}{text})) {
 
 				#determine font description from string
-				my ($attr_list, $text_raw, $accel_char) = Pango->parse_markup($self->{_items}{$key}{text}->get('text'));
-				my $font_desc = $attr_list->get_iterator->get_font;
+				my ($ret, $attr_list, $text_raw, $accel_char) = Pango::parse_markup($self->{_items}{$key}{text}->get('text'), -1, 0);
+				my $font_desc = Pango::FontDescription->new();
+				$attr_list->get_iterator->get_font($font_desc);
 
 				#apply current font settings to button
 				$self->{_font_btn_w}->set_font_name($font_desc ? $font_desc->to_string : $self->{_font});
@@ -3202,8 +3203,9 @@ sub set_and_save_drawing_properties {
 	} elsif ($item->isa('GooCanvas2::CanvasText')) {
 
 		#determine font description from string
-		my ($attr_list, $text_raw, $accel_char) = Pango->parse_markup($item->get('text'));
-		my $font_desc = $attr_list->get_iterator->get_font;
+		my ($ret, $attr_list, $text_raw, $accel_char) = Pango::parse_markup($item->get('text'), -1, 0);
+		my $font_desc = Pango::FontDescription->new();
+		$attr_list->get_iterator->get_font($font_desc);
 
 		#font color
 		$self->{_stroke_color_w}->set_rgba($self->{_items}{$key}{stroke_color});
@@ -3217,7 +3219,7 @@ sub set_and_save_drawing_properties {
 	$self->{_line_width}         = $self->{_line_spin_w}->get_value;
 	$self->{_stroke_color}       = $self->{_stroke_color_w}->get_rgba;
 	$self->{_fill_color}         = $self->{_fill_color_w}->get_rgba;
-	my $font_descr = Pango::FontDescription->from_string($self->{_font_btn_w}->get_font_name);
+	my $font_descr = Pango::FontDescription::from_string($self->{_font_btn_w}->get_font_name);
 	$self->{_font} = $self->{_font_btn_w}->get_font_name;
 
 	#unblock 'value-change' handlers for widgets
@@ -3298,7 +3300,7 @@ sub restore_drawing_properties {
 	$self->{_line_width}         = $self->{_line_spin_w}->get_value;
 	$self->{_stroke_color}       = $self->{_stroke_color_w}->get_rgba;
 	$self->{_fill_color}         = $self->{_fill_color_w}->get_rgba;
-	my $font_descr = Pango::FontDescription->from_string($self->{_font_btn_w}->get_font_name);
+	my $font_descr = Pango::FontDescription::from_string($self->{_font_btn_w}->get_font_name);
 	$self->{_font} = $self->{_font_btn_w}->get_font_name;
 
 	#unblock 'value-change' handlers for widgets
@@ -4098,8 +4100,9 @@ sub show_item_properties {
 			$font_btn = Gtk3::FontButton->new();
 
 			#determine font description from string
-			my ($attr_list, $text_raw, $accel_char) = Pango->parse_markup($self->{_items}{$key}{text}->get('text'));
-			my ($font_desc) = $attr_list->get_iterator->get_font;
+			my ($ret, $attr_list, $text_raw, $accel_char) = Pango::parse_markup($self->{_items}{$key}{text}->get('text'), -1, 0);
+			my $font_desc = Pango::FontDescription->new();
+			$attr_list->get_iterator->get_font($font_desc);
 
 			#apply current font settings to button
 			$font_btn->set_font_name($font_desc ? $font_desc->to_string : $self->{_font});
@@ -4208,8 +4211,8 @@ sub show_item_properties {
 		$font_btn = Gtk3::FontButton->new();
 
 		#determine font description from string
-		my ($attr_list, $text_raw, $accel_char) = Pango->parse_markup($item->get('text'));
-		my ($font_desc) = Pango::FontDescription->from_string($self->{_font});
+		my ($ret, $attr_list, $text_raw, $accel_char) = Pango::parse_markup($item->get('text'), -1, 0);
+		my ($font_desc) = Pango::FontDescription::from_string($self->{_font});
 
 		$font_hbox->pack_start($font_label, FALSE, TRUE,  12);
 		$font_hbox->pack_start($font_btn,   TRUE,  TRUE,  0);
@@ -4564,7 +4567,7 @@ sub apply_properties {
 				$fill_color = $stroke_color->get_rgba;
 			}
 
-			my $font_descr = Pango::FontDescription->from_string($font_btn->get_font_name);
+			my $font_descr = Pango::FontDescription::from_string($font_btn->get_font_name);
 			$self->{_items}{$key}{text}->set(
 				'text'         => "<span font_desc=' " . $font_btn->get_font_name . " ' >" . $digit . "</span>",
 				'fill-color-gdk-rgba' => $fill_color,
@@ -4657,7 +4660,7 @@ sub apply_properties {
 
 	#apply text options
 	if ($item->isa('GooCanvas2::CanvasText')) {
-		my $font_descr = Pango::FontDescription->from_string($font_btn->get_font_name);
+		my $font_descr = Pango::FontDescription::from_string($font_btn->get_font_name);
 
 		my $new_text = undef;
 		if ($textview) {
@@ -4666,7 +4669,7 @@ sub apply_properties {
 		} else {
 
 			#determine font description and text from string
-			my ($attr_list, $text_raw, $accel_char) = Pango->parse_markup($item->get('text'));
+			my ($ret, $attr_list, $text_raw, $accel_char) = Pango::parse_markup($item->get('text'), -1, 0);
 			$new_text = $text_raw;
 		}
 
@@ -4703,7 +4706,7 @@ sub modify_text_in_properties {
 	my $use_font       = shift;
 	my $use_font_color = shift;
 
-	my $font_descr = Pango::FontDescription->from_string($font_btn->get_font_name);
+	my $font_descr = Pango::FontDescription::from_string($font_btn->get_font_name);
 	my $texttag    = Gtk3::TextTag->new;
 
 	if ($use_font->get_active && $use_font_color->get_active) {

--- a/share/shutter/resources/modules/Shutter/Screenshot/SelectorAdvanced.pm
+++ b/share/shutter/resources/modules/Shutter/Screenshot/SelectorAdvanced.pm
@@ -129,7 +129,7 @@ sub select_advanced {
 					my $style     = $self->{_sc}->get_mainwindow->get_style_context;
 					my $sel_bg    = Gtk3::Gdk::RGBA::parse('#131313');
 					my $font_fam  = $style->get_font('normal')->get_family;
-					my $font_size = $style->get_font('normal')->get_size * $self->{_dpi_scale} / Pango->scale;
+					my $font_size = $style->get_font('normal')->get_size * $self->{_dpi_scale} / Pango::SCALE;
 
 					#create cairo context und layout
 					my $surface = Cairo::ImageSurface->create('argb32', $self->{_root}->{w}*$self->{_dpi_scale}, $self->{_root}->{h}*$self->{_dpi_scale});
@@ -140,7 +140,7 @@ sub select_advanced {
 					$cr->paint;
 
 					my $layout = Pango::Cairo::create_layout($cr);
-					$layout->set_width(int($mon1->{width} * $self->{_dpi_scale} / 2) * Pango->scale);
+					$layout->set_width(int($mon1->{width} * $self->{_dpi_scale} / 2) * Pango::SCALE);
 					$layout->set_alignment('left');
 					$layout->set_wrap('word');
 

--- a/share/shutter/resources/modules/Shutter/Screenshot/Window.pm
+++ b/share/shutter/resources/modules/Shutter/Screenshot/Window.pm
@@ -97,7 +97,7 @@ sub new {
 		my $style     = $self->{_main_gtk_window}->get_style_context;
 		my $sel_bg    = $style->get_background_color('selected');
 		my $font_fam  = $style->get_font('normal')->get_family;
-		my $font_size = $style->get_font('normal')->get_size / Pango->scale;
+		my $font_size = $style->get_font('normal')->get_size / Pango::SCALE;
 
 		#get current monitor
 		my $mon = $self->get_current_monitor;
@@ -128,7 +128,7 @@ sub new {
 
 				#pango layout
 				my $layout = Pango::Cairo::create_layout($cr);
-				$layout->set_width(($w - $icon->get_width - $font_size * 3) * Pango->scale);
+				$layout->set_width(($w - $icon->get_width - $font_size * 3) * Pango::SCALE);
 				$layout->set_alignment('left');
 				$layout->set_wrap('char');
 


### PR DESCRIPTION
…go API

'use Gtk3' would also set up namespace Pango, based on loader Glib::Object::Introspection. This loader conflicts w/ the common one applied by 'use Pango' (i.e. DynaLoader). So we get lots of CRITIICAL messages in former versions.

This commit has explicit 'use Pango' removed and mismatched interface tuned. Also pango-version related logics are cleaned up as Gtk3 has already required pango >= 1.20 since 3.0.0

Fix shutter-project/shutter#776