### PR TITLE
Fix PDF and PS export, #788

### DIFF
--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -83,8 +83,6 @@ sub save_pdf_ps_svg {
 	my $filetype = shift;
 	my $pixbuf = shift;
 
-	my $surface = undef;
-
 	my $class = {
 		pdf => 'Cairo::PdfSurface',
 		ps => 'Cairo::PsSurface',
@@ -92,7 +90,7 @@ sub save_pdf_ps_svg {
 	}->{$filetype};
 	
 	#0.8? => 72 / 90 dpi
-	$surface = $class->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
+	my $surface = $class->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
 	my $cr      = Cairo::Context->create($surface);
 	$cr->scale(0.8, 0.8);
 	Gtk3::Gdk::cairo_set_source_pixbuf($cr, $pixbuf, 0, 0);

--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -84,15 +84,15 @@ sub save_pdf_ps_svg {
 	my $pixbuf = shift;
 
 	my $surface = undef;
+
+	my $class = {
+		pdf => 'Cairo::PdfSurface',
+		ps => 'Cairo::PsSurface',
+		svg => 'Cairo::SvgSurface',
+	}->{$filetype};
 	
 	#0.8? => 72 / 90 dpi
-	if ($filetype eq 'pdf') {
-		$surface = Cairo::PdfSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
-	} elsif ($filetype eq 'ps') {
-		$surface = Cairo::PsSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
-	} elsif ($filetype eq 'svg') {
-		$surface = Cairo::SvgSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
-	}
+	$surface = $class->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
 	my $cr      = Cairo::Context->create($surface);
 	$cr->scale(0.8, 0.8);
 	Gtk3::Gdk::cairo_set_source_pixbuf($cr, $pixbuf, 0, 0);

--- a/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
+++ b/share/shutter/resources/modules/Shutter/Pixbuf/Save.pm
@@ -80,10 +80,19 @@ sub set_quality_setting {
 sub save_pdf_ps_svg {
 	my $self = shift;
 	my $filename = shift;
+	my $filetype = shift;
 	my $pixbuf = shift;
+
+	my $surface = undef;
 	
 	#0.8? => 72 / 90 dpi
-	my $surface = Cairo::SvgSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
+	if ($filetype eq 'pdf') {
+		$surface = Cairo::PdfSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
+	} elsif ($filetype eq 'ps') {
+		$surface = Cairo::PsSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
+	} elsif ($filetype eq 'svg') {
+		$surface = Cairo::SvgSurface->create($filename, $pixbuf->get_width * 0.8, $pixbuf->get_height * 0.8);
+	}
 	my $cr      = Cairo::Context->create($surface);
 	$cr->scale(0.8, 0.8);
 	Gtk3::Gdk::cairo_set_source_pixbuf($cr, $pixbuf, 0, 0);
@@ -175,7 +184,7 @@ sub save_pixbuf_to_file {
 
 	} elsif ($filetype eq 'pdf' || $filetype eq 'ps' || $filetype eq 'svg') {
 
-		$self->save_pdf_ps_svg($filename, $pixbuf);
+		$self->save_pdf_ps_svg($filename, $filetype, $pixbuf);
 
 		print "Saving file $filename, $filetype\n" if $self->{_common}->get_debug;
 


### PR DESCRIPTION
While refactoring Save.pm I simplified too much and didn't notice that there were different definitions of `$surface` depending on the file type. 