### PR TITLE
Switch to /etc/os-release to get system info

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -9469,13 +9469,17 @@ sub STARTUP {
 			print `uname -a`, "\n";
 		}
 
-		#issue
-		if (-f '/etc/os-release') {
-			if (File::Which::which('sed')) {
-				print `sed '1q;d' /etc/os-release`;
-				print `sed '5q;d' /etc/os-release`, "\n";
-			}
-		}
+		eval {
+			open my $fh, '<', '/etc/os-release' or die;
+			my %map = map {
+				chomp;
+				my ($key, $value) = split /=/, $_, 2;
+				$value =~ s/^(['"])(.*)\1$/$2/;
+				($key, $value)
+			} <$fh>;
+			say $map{NAME};
+		};
+		say "Cannot open /etc/os-release" if $@;
 
 		printf "Glib %s \n", $Glib::VERSION;
 		printf "Gtk3 %s \n", $Gtk3::VERSION;

--- a/bin/shutter
+++ b/bin/shutter
@@ -9477,7 +9477,8 @@ sub STARTUP {
 				$value =~ s/^(['"])(.*)\1$/$2/;
 				($key, $value)
 			} <$fh>;
-			say "$map{NAME} $map{VERSION_ID}$map{BUILD_ID}";
+			local $, = ' ';
+			say grep { $_ } map { $map{$_} } qw/NAME VERSION_ID BUILD_ID/;
 		};
 		say "Cannot open /etc/os-release" if $@;
 

--- a/bin/shutter
+++ b/bin/shutter
@@ -9477,7 +9477,7 @@ sub STARTUP {
 				$value =~ s/^(['"])(.*)\1$/$2/;
 				($key, $value)
 			} <$fh>;
-			say $map{NAME};
+			say "$map{NAME} $map{VERSION_ID}$map{BUILD_ID}";
 		};
 		say "Cannot open /etc/os-release" if $@;
 

--- a/bin/shutter
+++ b/bin/shutter
@@ -9470,9 +9470,10 @@ sub STARTUP {
 		}
 
 		#issue
-		if (-f '/etc/issue') {
-			if (File::Which::which('cat')) {
-				print `cat /etc/issue`, "\n";
+		if (-f '/etc/os-release') {
+			if (File::Which::which('sed')) {
+				print `sed '1q;d' /etc/os-release`;
+				print `sed '5q;d' /etc/os-release`, "\n";
 			}
 		}
 


### PR DESCRIPTION
The currently used `/etc/issue` seems to be less suiting (only gives `\S{PRETTY_NAME} \r (\l)` for me on Manjaro).

With `/etc/os-release` we would get

```
NAME="Manjaro Linux"
BUILD_ID=rolling
```
