### PR TITLE
Fixed .xpm cursor files to work with new glycin version

### DIFF
--- a/share/shutter/resources/icons/drawing_tool/cursor/arrow
+++ b/share/shutter/resources/icons/drawing_tool/cursor/arrow
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *arrow[] = {
+static char *arrow[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/censor
+++ b/share/shutter/resources/icons/drawing_tool/cursor/censor
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *censor[] = {
+static char *censor[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/ellipse
+++ b/share/shutter/resources/icons/drawing_tool/cursor/ellipse
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *ellipse[] = {
+static char *ellipse[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/freehand
+++ b/share/shutter/resources/icons/drawing_tool/cursor/freehand
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *freehand[] = {
+static char *freehand[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/line
+++ b/share/shutter/resources/icons/drawing_tool/cursor/line
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *line[] = {
+static char *line[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",
@@ -12,7 +12,7 @@ static char const *line[] = {
 "....+....                       ",
 "   .+.                          ",
 "   .+.                          ",
-"   ...        .                  ",
+"   ...        .                 ",
 "              +                 ",
 "            .+ +.               ",
 "           .+...+.              ",

--- a/share/shutter/resources/icons/drawing_tool/cursor/number
+++ b/share/shutter/resources/icons/drawing_tool/cursor/number
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *number[] = {
+static char *number[] = {
 "32 32 3 1 7 7",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/rect
+++ b/share/shutter/resources/icons/drawing_tool/cursor/rect
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *rect[] = {
+static char *rect[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/text
+++ b/share/shutter/resources/icons/drawing_tool/cursor/text
@@ -1,5 +1,5 @@
 /* XPM */
-static char const *text[] = {
+static char *text[] = {
 "32 32 3 1 7 7",
 " 	c None",
 ".	c #FFFFFF",


### PR DESCRIPTION
After the update of gdk-pixbuf2 to 2.44.4 XPM files are loaded using glycin. Glycin is unable to parse the `const` keyword thus removing it. See also https://github.com/image-rs/image-extras/issues/36