### PR TITLE
Revert "Fixed .xpm cursor files to work with new glycin version"

### DIFF
--- a/share/shutter/resources/icons/drawing_tool/cursor/arrow
+++ b/share/shutter/resources/icons/drawing_tool/cursor/arrow
@@ -1,5 +1,5 @@
 /* XPM */
-static char *arrow[] = {
+static char const *arrow[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/censor
+++ b/share/shutter/resources/icons/drawing_tool/cursor/censor
@@ -1,5 +1,5 @@
 /* XPM */
-static char *censor[] = {
+static char const *censor[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/ellipse
+++ b/share/shutter/resources/icons/drawing_tool/cursor/ellipse
@@ -1,5 +1,5 @@
 /* XPM */
-static char *ellipse[] = {
+static char const *ellipse[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/freehand
+++ b/share/shutter/resources/icons/drawing_tool/cursor/freehand
@@ -1,5 +1,5 @@
 /* XPM */
-static char *freehand[] = {
+static char const *freehand[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/line
+++ b/share/shutter/resources/icons/drawing_tool/cursor/line
@@ -1,5 +1,5 @@
 /* XPM */
-static char *line[] = {
+static char const *line[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",
@@ -12,7 +12,7 @@ static char *line[] = {
 "....+....                       ",
 "   .+.                          ",
 "   .+.                          ",
-"   ...        .                 ",
+"   ...        .                  ",
 "              +                 ",
 "            .+ +.               ",
 "           .+...+.              ",

--- a/share/shutter/resources/icons/drawing_tool/cursor/number
+++ b/share/shutter/resources/icons/drawing_tool/cursor/number
@@ -1,5 +1,5 @@
 /* XPM */
-static char *number[] = {
+static char const *number[] = {
 "32 32 3 1 7 7",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/rect
+++ b/share/shutter/resources/icons/drawing_tool/cursor/rect
@@ -1,5 +1,5 @@
 /* XPM */
-static char *rect[] = {
+static char const *rect[] = {
 "32 32 3 1 4 4",
 " 	c None",
 ".	c #FFFFFF",

--- a/share/shutter/resources/icons/drawing_tool/cursor/text
+++ b/share/shutter/resources/icons/drawing_tool/cursor/text
@@ -1,5 +1,5 @@
 /* XPM */
-static char *text[] = {
+static char const *text[] = {
 "32 32 3 1 7 7",
 " 	c None",
 ".	c #FFFFFF",


### PR DESCRIPTION
Reverts shutter-project/shutter#809

PR #809 implements a workaround for loading cursor icon errors in recent glycin versions. With #809 the editor launches and is usable, but the cursor icons for various tools aren't displayed properly.

The proper fix is to revert #809 and wait for a fix in glycin. glycin uses image-rs/image-extras for loading XPM files. A fix in image-rs/image-extras has been released last week: https://github.com/image-rs/image-extras/pull/47 Now we just need to wait for the next glycin version to pick it up, reported upstream: https://gitlab.gnome.org/GNOME/glycin/-/work_items/290

I propose to keep this as a draft as long as glycin is build with the broken image-rs/image-extras dependency, then merge it and thus revert #809 after the fixed glycin is released.