### PR TITLE
Added option to copy edited screenshot to clipboard when saving it in the Drawing Tool

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -815,8 +815,7 @@ sub STARTUP {
 	my $file_vbox    = Gtk3::VBox->new(FALSE, 0);
 	my $save_vbox    = Gtk3::VBox->new(FALSE, 0);
 	my $capture_vbox = Gtk3::VBox->new(FALSE, 0);
-	my $drawing_tool_icons_vbox    = Gtk3::VBox->new(FALSE, 0);
-	my $drawing_tool_save_to_clipboard_vbox    = Gtk3::VBox->new(FALSE, 0);
+	my $drawing_tool_vbox    = Gtk3::VBox->new(FALSE, 0);
 
 	my $scale_box                           = Gtk3::HBox->new(FALSE, 0);
 	my $filetype_box                        = Gtk3::HBox->new(FALSE, 0);
@@ -2487,11 +2486,11 @@ sub STARTUP {
 	$capture_vbox->pack_start($delay_box,  TRUE,  TRUE, 3);
 	$capture_frame->add($capture_vbox);
 
-	$drawing_tool_icons_vbox->pack_start($drawing_tool_light_icons_box,    TRUE,  TRUE, 3);
-    $drawing_tool_icons_vbox->pack_start($drawing_tool_dark_icons_box,     TRUE,  TRUE, 3);
-    $drawing_tool_icons_vbox->pack_start($drawing_tool_auto_icons_box,     TRUE,  TRUE, 3);
-	$drawing_tool_icons_vbox->pack_start($drawing_tool_save_to_clipboard_box,    TRUE,  TRUE, 3);	
-    $drawing_tool_frame->add($drawing_tool_icons_vbox);
+	$drawing_tool_vbox->pack_start($drawing_tool_light_icons_box,    TRUE,  TRUE, 3);
+    $drawing_tool_vbox->pack_start($drawing_tool_dark_icons_box,     TRUE,  TRUE, 3);
+    $drawing_tool_vbox->pack_start($drawing_tool_auto_icons_box,     TRUE,  TRUE, 3);
+	$drawing_tool_vbox->pack_start($drawing_tool_save_to_clipboard_box,    TRUE,  TRUE, 3);	
+    $drawing_tool_frame->add($drawing_tool_vbox);
 	
 	#all labels = one size
 	$scale_label->set_alignment(0, 0.5);
@@ -4739,7 +4738,7 @@ sub STARTUP {
 		$settings{'general'}->{'drawing_tool_light_icons'}      = $drawing_tool_light_icons_active->get_active();
 		$settings{'general'}->{'drawing_tool_dark_icons'}       = $drawing_tool_dark_icons_active->get_active();
 		$settings{'general'}->{'drawing_tool_auto_icons'}       = $drawing_tool_auto_icons_active->get_active();
-		$settings{'general'}->{'drawing_tool_auto_icons'}       = $drawing_tool_auto_icons_active->get_active();
+		$settings{'general'}->{'drawing_tool_save_to_clipboard'}= $drawing_tool_save_to_clipboard_active->get_active();
 		#wrksp -> submenu
 		if ($x11_supported) {
 			$settings{'general'}->{'current_monitor_active'} = $current_monitor_active->get_active;

--- a/bin/shutter
+++ b/bin/shutter
@@ -317,6 +317,7 @@ my $delete_on_close_active;
 my $drawing_tool_auto_icons_active;
 my $drawing_tool_dark_icons_active;
 my $drawing_tool_light_icons_active;
+my $drawing_tool_save_to_clipboard_active;
 my $filename;
 my $fname_autocopy_active;
 my $fs_active;
@@ -815,6 +816,7 @@ sub STARTUP {
 	my $save_vbox    = Gtk3::VBox->new(FALSE, 0);
 	my $capture_vbox = Gtk3::VBox->new(FALSE, 0);
 	my $drawing_tool_icons_vbox    = Gtk3::VBox->new(FALSE, 0);
+	my $drawing_tool_save_to_clipboard_vbox    = Gtk3::VBox->new(FALSE, 0);
 
 	my $scale_box                           = Gtk3::HBox->new(FALSE, 0);
 	my $filetype_box                        = Gtk3::HBox->new(FALSE, 0);
@@ -831,6 +833,7 @@ sub STARTUP {
 	my $drawing_tool_light_icons_box        = Gtk3::HBox->new(FALSE, 0);
 	my $drawing_tool_dark_icons_box         = Gtk3::HBox->new(FALSE, 0);
 	my $drawing_tool_auto_icons_box         = Gtk3::HBox->new(FALSE, 0);
+	my $drawing_tool_save_to_clipboard_box  = Gtk3::HBox->new(FALSE, 0);
 
 	#actions
 	my $actions_vbox = Gtk3::VBox->new(FALSE, 0);
@@ -1527,6 +1530,22 @@ sub STARTUP {
 	}
 
 	#end - drawing tool custom icons
+	#--------------------------------------
+
+	#drawing_tool_save_to_clipboard_active
+	#--------------------------------------
+	$drawing_tool_save_to_clipboard_active = Gtk3::CheckButton->new_with_label($d->get("Automatically copy screenshot to clipboard when saving"));
+	$drawing_tool_save_to_clipboard_box->pack_start($drawing_tool_save_to_clipboard_active, FALSE, TRUE, 12);
+
+	if (defined $settings_xml->{'general'}->{'drawing_tool_save_to_clipboard'}) {
+		$drawing_tool_save_to_clipboard_active->set_active($settings_xml->{'general'}->{'drawing_tool_save_to_clipboard'});
+	} else {
+		$drawing_tool_save_to_clipboard_active->set_active(FALSE);
+	}
+
+	$drawing_tool_save_to_clipboard_active->set_tooltip_text($d->get("Automatically copy screenshot to the clipboard when saving the image in the Drawing Tool"));
+
+	#end - drawing_tool_save_to_clipboard_active
 	#--------------------------------------
 
 	#program
@@ -2468,11 +2487,12 @@ sub STARTUP {
 	$capture_vbox->pack_start($delay_box,  TRUE,  TRUE, 3);
 	$capture_frame->add($capture_vbox);
 
-        $drawing_tool_icons_vbox->pack_start($drawing_tool_light_icons_box,    TRUE,  TRUE, 3);
-        $drawing_tool_icons_vbox->pack_start($drawing_tool_dark_icons_box,     TRUE,  TRUE, 3);
-        $drawing_tool_icons_vbox->pack_start($drawing_tool_auto_icons_box,     TRUE,  TRUE, 3);
-        $drawing_tool_frame->add($drawing_tool_icons_vbox);
-
+	$drawing_tool_icons_vbox->pack_start($drawing_tool_light_icons_box,    TRUE,  TRUE, 3);
+    $drawing_tool_icons_vbox->pack_start($drawing_tool_dark_icons_box,     TRUE,  TRUE, 3);
+    $drawing_tool_icons_vbox->pack_start($drawing_tool_auto_icons_box,     TRUE,  TRUE, 3);
+	$drawing_tool_icons_vbox->pack_start($drawing_tool_save_to_clipboard_box,    TRUE,  TRUE, 3);	
+    $drawing_tool_frame->add($drawing_tool_icons_vbox);
+	
 	#all labels = one size
 	$scale_label->set_alignment(0, 0.5);
 	$filetype_label->set_alignment(0, 0.5);
@@ -2488,7 +2508,7 @@ sub STARTUP {
 	$vbox_basic->pack_start($file_frame,            FALSE, TRUE, 3);
 	$vbox_basic->pack_start($save_frame,            FALSE, TRUE, 3);
 	$vbox_basic->pack_start($capture_frame,         FALSE, TRUE, 3);
-        $vbox_basic->pack_start($drawing_tool_frame,    FALSE, TRUE, 3);
+	$vbox_basic->pack_start($drawing_tool_frame,    FALSE, TRUE, 3);
 	$vbox_basic->set_border_width(5);
 
 	#settings actions tab
@@ -4719,6 +4739,7 @@ sub STARTUP {
 		$settings{'general'}->{'drawing_tool_light_icons'}      = $drawing_tool_light_icons_active->get_active();
 		$settings{'general'}->{'drawing_tool_dark_icons'}       = $drawing_tool_dark_icons_active->get_active();
 		$settings{'general'}->{'drawing_tool_auto_icons'}       = $drawing_tool_auto_icons_active->get_active();
+		$settings{'general'}->{'drawing_tool_auto_icons'}       = $drawing_tool_auto_icons_active->get_active();
 		#wrksp -> submenu
 		if ($x11_supported) {
 			$settings{'general'}->{'current_monitor_active'} = $current_monitor_active->get_active;
@@ -6099,7 +6120,7 @@ sub STARTUP {
 			$drawing_tool->show(
 				$session_screens{$key}->{'long'}, $session_screens{$key}->{'filetype'},   $session_screens{$key}->{'mime_type'},
 				$session_screens{$key}->{'name'}, $session_screens{$key}->{'is_unsaved'}, \%session_screens,
-				$drawing_tool_icons
+				$drawing_tool_icons,              $drawing_tool_save_to_clipboard_active->get_active
 			);
 		}
 

--- a/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
+++ b/share/shutter/resources/modules/Shutter/Draw/DrawingTool.pm
@@ -240,7 +240,8 @@ sub show {
 	$self->{_name}        = shift;
 	$self->{_is_unsaved}  = shift;
 	$self->{_import_hash} = shift;
-	my $icon_theme = shift;
+	my $icon_theme	      = shift;
+	$self->{_cp_to_cb_on_save}  = shift;
 
 	#gettext
 	$self->{_d} = $self->{_sc}->get_gettext;
@@ -1895,8 +1896,11 @@ sub save {
 
 		#save pixbuf to file
 		my $pixbuf_save = Shutter::Pixbuf::Save->new($self->{_sc}, $self->{_drawing_window});
+		#save pixbuf to clipboard
+		if ($self->{_cp_to_cb_on_save}) {
+			$self->{_clipboard}->set_image($pixbuf);
+		}
 		return $pixbuf_save->save_pixbuf_to_file($pixbuf, $filename, $filetype);
-
 	}
 
 }


### PR DESCRIPTION
This way users won't have to open the updated file first and can directly paste the updated image.