### PR TITLE
Get rid of annoying warnings in Wayland sessions

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -3306,7 +3306,7 @@ sub STARTUP {
 					return FALSE;
 				});
 		} else {
-			-Glib::Timeout->add(50, # Add 50ms timeout to give Wayland enough time for mapping the widget
+			Glib::Timeout->add(50, # Add 50ms timeout to give Wayland enough time for mapping the widget
 				sub {
 					fct_update_info_and_tray("session");
 					return FALSE;
@@ -4131,10 +4131,9 @@ sub STARTUP {
 			);
 		} else {
 			if ($tray_legacy) {
-            $tray_legacy->set_visible(0);
-            $tray_legacy = undef;
-		}
-
+				$tray_legacy->set_visible(0);
+				$tray_legacy = undef;
+			}
 
 			if ($appindicator && !$tray_libappindicator) {
 				# Fallback to AppIndicator. This one doesn't allow left-click signal, but it seems to be the only option for Gnome on Ubuntu 21.04...

--- a/bin/shutter
+++ b/bin/shutter
@@ -1682,7 +1682,6 @@ sub STARTUP {
 	#bordereffect
 	#--------------------------------------
 	$bordereffect_active = Gtk3::CheckButton->new;
-	$bordereffect_active->set_active(TRUE);
 
 	my $bordereffect_label  = Gtk3::Label->new($d->get("Border") . ":");
 	$bordereffect        = Gtk3::SpinButton->new_with_range(1, 100, 1);
@@ -3263,7 +3262,7 @@ sub STARTUP {
 
 		my $key = fct_get_file_by_index($int);
 		if ($key) {
-			Glib::Idle->add(
+			Glib::Timeout->add(50, # Add 50ms timeout to give Wayland enough time for mapping the widget
 				sub {
 
 					#is key still current page?
@@ -3307,7 +3306,7 @@ sub STARTUP {
 					return FALSE;
 				});
 		} else {
-			Glib::Idle->add(
+			-Glib::Timeout->add(50, # Add 50ms timeout to give Wayland enough time for mapping the widget
 				sub {
 					fct_update_info_and_tray("session");
 					return FALSE;
@@ -3340,7 +3339,7 @@ sub STARTUP {
 			return TRUE;
 		}
 
-		Glib::Idle->add(
+		Glib::Timeout->add(50, # Add 50ms timeout to give Wayland enough time for mapping the widget
 			sub {
 
 				#hide window and block sontrols
@@ -4101,13 +4100,19 @@ sub STARTUP {
 	#--------------------------------------
 
 	sub fct_try_init_tray {
-		$tray_legacy = Gtk3::StatusIcon->new();
-		$tray_legacy->set_from_icon_name("shutter-panel");
-		$tray_legacy->set_visible(1);
+		if ($x11_supported) {
+             $tray_legacy = Gtk3::StatusIcon->new();
+             $tray_legacy->set_from_icon_name("shutter-panel");
+             $tray_legacy->set_visible(1);
+        } else {
+			 $tray_legacy = undef;
+        }
+
 
 		fct_update_gui();
 
-		if ($tray_legacy->is_embedded) {
+		if ($tray_legacy && $tray_legacy->is_embedded) {
+
 			if ($tray_libappindicator) {
 				$tray_libappindicator->set_status('passive');
 				$tray_libappindicator = undef;
@@ -4125,8 +4130,11 @@ sub STARTUP {
 				$tray
 			);
 		} else {
-			$tray_legacy->set_visible(0);
-			$tray_legacy = undef;
+			if ($tray_legacy) {
+            $tray_legacy->set_visible(0);
+            $tray_legacy = undef;
+		}
+
 
 			if ($appindicator && !$tray_libappindicator) {
 				# Fallback to AppIndicator. This one doesn't allow left-click signal, but it seems to be the only option for Gnome on Ubuntu 21.04...


### PR DESCRIPTION
Shutter produces Gtk-CRITICAL warnings on Wayland:

`gtk_widget_get_scale_factor: assertion 'GTK_IS_WIDGET (widget)' failed`

This kind of warnings occurs on several occasions. This should get rid of them (hopefully all of them).

In particular:

- set checkbutton active only after it is packed into the Gtk layout
- use a 50ms timeout such that Wayland has enough time to map a widget
- disable tray icon on Wayland