### PR TITLE
Add proper error handling if Path::Class is missing

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -197,6 +197,7 @@ my $nautilus_sendto = TRUE;
 my $goocanvas       = TRUE;
 my $exiftool        = TRUE;
 my $appindicator    = TRUE;
+my $pathclass		= TRUE;
 fct_init_depend();
 
 #--------------------------------------
@@ -8359,6 +8360,9 @@ sub STARTUP {
 						#parse filename
 						my ($name, $folder, $type) = fileparse($ukey, qr/\.[^.]*/);
 
+						#skip Imgur if optional dependency Path::Class not met
+						next if ($name eq 'Imgur' && !$pathclass);
+
 						#~ print $name, $folder, $type, "\n";
 
 						if (   !exists $accounts{$name}
@@ -9390,6 +9394,13 @@ sub STARTUP {
 		if ($@) {
 			warn "WARNING: Image::ExifTool is missing --> writing Exif information will be disabled!\n\n";
 			$exiftool = FALSE;
+		}
+
+        #Path::Class
+		eval { require Path::Class };
+		if ($@) {
+			warn "WARNING: Path::Class is missing --> uploading to Imgur will be disabled!\n\n";
+			$pathclass = FALSE;
 		}
 
 		#dev-libs/libappindicator[introspection]


### PR DESCRIPTION
Path::Class is an optional dependency, which is only required for the Imgur.pm upload plugin. So far Shutter didn't handle it properly and you got non-fatal errors on launch if the dependency was not met:

```
INFO: new upload-plugin information detected - /home/photon/Downloads/shutter-master/share/shutter/resources/system/upload_plugins/upload/Imgur
Can't locate Path/Class.pm in @INC (you may need to install the Path::Class module) (@INC entries checked: /home/photon/Downloads/shutter-master/share/shutter/resources/modules /usr/lib/perl5/5.42/site_perl /usr/share/perl5/site_perl /usr/lib/perl5/5.42/vendor_perl /usr/share/perl5/vendor_perl /usr/lib/perl5/5.42/core_perl /usr/share/perl5/core_perl) at /home/photon/Downloads/shutter-master/share/shutter/resources/system/upload_plugins/upload/Imgur.pm line 77.
BEGIN failed--compilation aborted at /home/photon/Downloads/shutter-master/share/shutter/resources/system/upload_plugins/upload/Imgur.pm line 77.

ERROR: upload-plugin exists but does not work properly - /home/photon/Downloads/shutter-master/share/shutter/resources/system/upload_plugins/upload/Imgur
```

Also, the update-plugin dialog popped up for some milliseconds at each launch. 

With this PR the dialog won't appear each launch and you get a kind of clean warning similar to other warnings for unmet optional dependencies:

```
WARNING: Path::Class is missing --> uploading to Imgur will be disabled!

 at ./shutter_new line 9410.
        Shutter::App::fct_init_depend() called at ./shutter_new line 201
```

I couldn't figure out how to get rid of the last two lines but this happens to all other warnings as well, so not related to this PR.