### PR TITLE
Fix profile loading on Wayland

### DIFF
--- a/bin/shutter
+++ b/bin/shutter
@@ -5086,7 +5086,7 @@ modes are currently experimental, your desktop environment might fall back to an
 					$settings_xml->{'general'}->{'folder_force'} = TRUE;
 
 					#wrksp -> submenu
-					$current_monitor_active->set_active($settings_xml->{'general'}->{'current_monitor_active'});
+					$current_monitor_active->set_active($settings_xml->{'general'}->{'current_monitor_active'}) if defined $current_monitor_active;
 
 					#determining timeout
 					my $web_menu = $st->{_web}->get_menu;


### PR DESCRIPTION
`$current_monitor_active` is undefined on Wayland, so we need to check if it is defined before working with it.